### PR TITLE
Enforce octets and croak() if given a string containing code points above U+00FF

### DIFF
--- a/XS.xs
+++ b/XS.xs
@@ -159,6 +159,14 @@ uri_encode(SV *uri)
       croak("uri_encode() requires a scalar argument to encode!");
     }
     src = SvPV_nomg_const(uri, len);
+    if (SvUTF8(uri))
+    {
+      uri = sv_2mortal(newSVpvn(src, len));
+      SvUTF8_on(uri);
+      if (!sv_utf8_downgrade(uri, TRUE))
+          croak("Wide character in octet string");
+      src = SvPV_const(uri, len);
+    }
     uri_encode_dsv(src, len, TARG);
     PUSHTARG;
 
@@ -175,6 +183,14 @@ uri_decode(SV *uri)
       croak("uri_decode() requires a scalar argument to decode!");
     }
     src = SvPV_nomg_const(uri, len);
+    if (SvUTF8(uri))
+    {
+      uri = sv_2mortal(newSVpvn(src, len));
+      SvUTF8_on(uri);
+      if (!sv_utf8_downgrade(uri, TRUE))
+          croak("Wide character in octet string");
+      src = SvPV_const(uri, len);
+    }
     uri_decode_dsv(src, len, TARG);
     PUSHTARG;
 

--- a/XS.xs
+++ b/XS.xs
@@ -153,11 +153,12 @@ uri_encode(SV *uri)
     const char *src;
     size_t len;
   PPCODE:
+    SvGETMAGIC(uri);
     if (!SvOK(uri))
     {
       croak("uri_encode() requires a scalar argument to encode!");
     }
-    src = SvPV_const(uri, len);
+    src = SvPV_nomg_const(uri, len);
     uri_encode_dsv(src, len, TARG);
     PUSHTARG;
 
@@ -168,11 +169,12 @@ uri_decode(SV *uri)
     const char *src;
     size_t len;
   PPCODE:
+    SvGETMAGIC(uri);
     if (!SvOK(uri))
     {
       croak("uri_decode() requires a scalar argument to decode!");
     }
-    src = SvPV_const(uri, len);
+    src = SvPV_nomg_const(uri, len);
     uri_decode_dsv(src, len, TARG);
     PUSHTARG;
 

--- a/t/xs.t
+++ b/t/xs.t
@@ -13,6 +13,10 @@ subtest encode => sub {
   is uri_encode("~*'()"), "~%2A%27%28%29";
   is uri_encode("<\">"), "%3C%22%3E";
   is uri_encode("ABC\x00DEF"), "ABC%00DEF", 'constains encoded null character';
+  {
+    use utf8;
+    is uri_encode("åäö"), '%E5%E4%F6', 'native characters (Latin1)';
+  }
 };
 
 subtest decode => sub {
@@ -32,8 +36,12 @@ subtest decode => sub {
 subtest exceptions => sub {
   eval { URI::Encode::XS::uri_encode(undef) };
   like $@, qr/uri_encode\(\) requires a scalar argument to encode!/, 'croak on undef';
+  eval { URI::Encode::XS::uri_encode("\x{263A}") };
+  like $@, qr/Wide character in octet string/, 'croak on non-octet string';
   eval { URI::Encode::XS::uri_decode(undef) };
   like $@, qr/uri_decode\(\) requires a scalar argument to decode!/, 'croak on undef';
+  eval { URI::Encode::XS::uri_decode("\x{263A}") };
+  like $@, qr/Wide character in octet string/, 'croak on non-octet string';
 };
 
 done_testing();


### PR DESCRIPTION
This pull request addresses issue #4.
